### PR TITLE
[#167151122] Fix max_allowed_payment_amount value on service edit

### DIFF
--- a/src/pages/SubscriptionService.tsx
+++ b/src/pages/SubscriptionService.tsx
@@ -40,7 +40,7 @@ class SubscriptionService extends Component<Props, SubscriptionServiceState> {
     const name = target.name;
     const serviceDecoding = Service.decode({
       ...this.state.service,
-      [name]: value
+      [name]: name === "max_allowed_payment_amount" ? Number(value) : value
     });
     if (serviceDecoding.isRight()) {
       this.setState({


### PR DESCRIPTION
This PR fixes the value type of the edited `max_allowed_payment_amount` property of the `Service` object in order to make it compliant with its interface definition.